### PR TITLE
feat: convert output to framework results

### DIFF
--- a/example/krm-function-input.yaml
+++ b/example/krm-function-input.yaml
@@ -28,6 +28,16 @@ items:
 - kind: Service
   apiVersion: v1
   metadata:
+    name: service2-invalid
+  spec:
+    type: ClusterIP
+    ports:
+    - protocol: TCP
+      port: 8666x
+      targetPort: 8080
+- kind: Service
+  apiVersion: v1
+  metadata:
     name: service-valid
   spec:
     type: ClusterIP


### PR DESCRIPTION
Hi  👋

This PR is for converting Json error output to Yaml format to be more readable 

## Build the tool
`go build -o 'dist/kubeconformvalidator' .
`
## Testing using /example directory :
`cat example/krm-function-input.yaml| ./dist/kubeconformvalidator
`

#### The output display in `framework.Results` format:

```
apiVersion: config.kubernetes.io/v1
kind: ResourceList
items: []
functionConfig:
  kind: KubeconformValidator
  apiVersion: validators.kustomize.aabouzaid.com/v1alpha1
  metadata:
    name: validate
  spec:
    config:
      output: json
    args:
    - -strict
    - -output
    - text
results:
- message: expected integer, but got string
  severity: error
  resourceRef:
    kind: Service
    name: service-invalid
  field:
    path: /spec/ports/0/port
    proposedValue: 1
- message: expected integer, but got string
  severity: error
  resourceRef:
    kind: Service
    name: service2-invalid
  field:
    path: /spec/ports/0/port
    proposedValue: 1
```

Thanks